### PR TITLE
Proposed solution to platform recognition

### DIFF
--- a/include/MidiConstants.h
+++ b/include/MidiConstants.h
@@ -27,16 +27,7 @@ Midi parsing taken from openFrameworks addon ofxMidi by Theo Watson & Dan Wilcox
 
 
 #pragma once
-//
-#if defined( linux )
-#warning "Using MIDI LINUX"
-	#define __LINUX_ALSASEQ__
-#elif defined(WIN32)
-	#define __WINDOWS_MM__
-#elif defined(__APPLE__)
-#warning "Using MIDI MAC"
-	#define __MACOSX_CORE__
-#endif
+
 
 
 // channel info

--- a/include/MidiHeaders.h
+++ b/include/MidiHeaders.h
@@ -29,6 +29,7 @@ Midi parsing taken from openFrameworks addon ofxMidi by Theo Watson & Dan Wilcox
 
 #include <string>
 #include <exception>
+
 #include "MidiConstants.h"
 #include "MidiExceptions.h"
 #include "MidiMessage.h"

--- a/include/MidiHub.h
+++ b/include/MidiHub.h
@@ -29,10 +29,7 @@
 #pragma once
 
 #include "MidiHeaders.h"
-/*#include "MidiConstants.h"
-#include "MidiIn.h"
-//#include "MidiOut.h"
-#include "MidiMessage.h"*/
+
 
 namespace cinder { namespace midi {	
 	

--- a/include/MidiIn.h
+++ b/include/MidiIn.h
@@ -30,19 +30,13 @@ Midi parsing taken from openFrameworks addon ofxMidi by Theo Watson & Dan Wilcox
 
 
 #pragma once
+
 #include <vector>
 #include <string>
 #include <iostream>
+
 #include "MidiHeaders.h"
-#include "MidiConstants.h"
- #include "boost/signals2.hpp"
-/*
-#include "MidiConstants.h"
-#include "RtMidi.h"
-#include <deque>
-#include "MidiExceptions.h"
-#include "MidiMessage.h"
-*/
+#include "cinder/Signals.h"
 
 
 
@@ -67,7 +61,7 @@ public:
 	std::vector<std::string> mPortNames;
 	std::string getName()	{ return mName; };
 	std::string getPortName(int number);
-	boost::signals2::signal<void(Message)> midiSignal;	
+    signals::Signal<void(Message)> midiSignal;
 	
 	//typedef boost::signal<void (Message*)> signal_t;
 	// bool hasWaitingMessages();

--- a/include/MidiMessage.h
+++ b/include/MidiMessage.h
@@ -29,8 +29,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 
-
-
 namespace cinder { namespace midi {
 
 	class Message {

--- a/include/MidiOut.h
+++ b/include/MidiOut.h
@@ -26,14 +26,10 @@ Midi parsing taken from openFrameworks addon ofxMidi by Theo Watson & Dan Wilcox
 
 #pragma once
 
-//#include "MidiHeaders.h"
 #include "cinder/app/App.h"
-#include "RtMidi.h"
 
-#include "MidiConstants.h"
-/*#include "MidiExceptions.h"
-#include "MidiMessage.h"
-*/
+#include "MidiHeaders.h"
+
 
 namespace cinder { namespace midi {
 ///

--- a/lib/RtMidi.h
+++ b/lib/RtMidi.h
@@ -50,6 +50,7 @@
 #include <string>
 #include <vector>
 
+
 /************************************************************************/
 /*! \class RtMidiError
     \brief Exception handling class for RtMidi.
@@ -566,6 +567,15 @@ inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, vo
 // MidiInApi and MidiOutApi subclass prototypes.
 //
 // **************************************************************** //
+
+// Cinder Platform
+#if defined( CINDER_LINUX )
+	#define __LINUX_ALSASEQ__
+#elif defined( CINDER_MSW )
+	#define __WINDOWS_MM__
+#elif defined( CINDER_MAC )
+	#define __MACOSX_CORE__
+#endif
 
 #if !defined(__LINUX_ALSA__) && !defined(__UNIX_JACK__) && !defined(__MACOSX_CORE__) && !defined(__WINDOWS_MM__)
   #define __RTMIDI_DUMMY__

--- a/sample/src/sampleApp.cpp
+++ b/sample/src/sampleApp.cpp
@@ -40,6 +40,7 @@ void MidiTestApp::midiListener(midi::Message msg){
 			"Velocity: " + toString(msg.velocity);
 		break;
 	case MIDI_NOTE_OFF:
+        notes[msg.pitch] = 0;
 		break;
 	case MIDI_CONTROL_CHANGE:
 		cc[msg.control] = msg.value;
@@ -90,6 +91,7 @@ void MidiTestApp::draw()
 	gl::clear( Color( 0, 0, 0 ) );
 	gl::pushMatrices();
 	gl::translate(getWindowCenter());
+    
 	for (int i = 0; i < notes.size(); i++)
 	{
 		float x = 200*sin((i*2.83) * M_PI / 180);
@@ -112,4 +114,7 @@ void MidiTestApp::draw()
 
 
 
-CINDER_APP( MidiTestApp, RendererGl )
+CINDER_APP( MidiTestApp, RendererGl( RendererGl::Options().msaa( 4 ) ), [](App::Settings* settings)
+{
+    settings->setWindowSize( 600, 600 );
+} )

--- a/sample/src/sampleApp.cpp
+++ b/sample/src/sampleApp.cpp
@@ -2,9 +2,8 @@
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
 #include "cinder/Utilities.h"
-#include "MidiIn.h"
-#include "MidiConstants.h"
-#include "MidiMessage.h"
+
+#include "MidiHeaders.h"
 #include "cinder/Font.h"
 
 using namespace ci;

--- a/sample/xcode/MidiTest.xcodeproj/project.pbxproj
+++ b/sample/xcode/MidiTest.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		8D1107320486CEB800E47090 /* MidiTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MidiTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97645778D955423C813975E1 /* MidiIn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MidiIn.h; path = ../../include/MidiIn.h; sourceTree = "<group>"; };
 		9F20344637F641D3A05CAC3C /* MidiHub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MidiHub.h; path = ../../include/MidiHub.h; sourceTree = "<group>"; };
-		B5C7F470885A48289F6665F7 /* RtError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RtError.h; path = ../../lib/RtError.h; sourceTree = "<group>"; };
 		B6CE3523F9E74055B55061CF /* MidiTest_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = MidiTest_Prefix.pch; sourceTree = "<group>"; };
 		BED3AFF3A43D4C0DA3E9541F /* MidiConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MidiConstants.h; path = ../../include/MidiConstants.h; sourceTree = "<group>"; };
 		E47846BE6A934F11B55BFE72 /* CoreMIDI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMIDI.framework; path = System/Library/Frameworks/CoreMIDI.framework; sourceTree = SDKROOT; };
@@ -218,7 +217,6 @@
 		F3560099658D4D859B0F29C5 /* lib */ = {
 			isa = PBXGroup;
 			children = (
-				B5C7F470885A48289F6665F7 /* RtError.h */,
 				6121441195434238986FF026 /* RtMidi.h */,
 				031195969B714B93942EC19C /* RtMidi.cpp */,
 			);

--- a/src/MidiIn.cpp
+++ b/src/MidiIn.cpp
@@ -113,7 +113,8 @@ namespace cinder { namespace midi {
 				break;
 			}
         
-            midiSignal.emit( msg ) ;
+            // TODO: Ensure thread safety (or stick with boost)
+            midiSignal.emit( msg );
 		}
 
 		// bool Input::hasWaitingMessages(){

--- a/src/MidiIn.cpp
+++ b/src/MidiIn.cpp
@@ -112,7 +112,8 @@ namespace cinder { namespace midi {
 			default:
 				break;
 			}
-			midiSignal(msg);
+        
+            midiSignal.emit( msg ) ;
 		}
 
 		// bool Input::hasWaitingMessages(){


### PR DESCRIPTION
Hey.

I don't know if this is the best header structure but I cleaned up a lot of the includes to just use MidiHeader.h where needed as there was lots of duplication. This has also added back the automatic platform recognition (tested on OSX at least) and the sample builds out of the box (which also looks a bit better).

This also switches to cinder/Signals instead of boost/signals2 (so it builds out of the box with the latest cinder branch which doesnt include boost/signals2). HOWEVER, whilst the midi functionality seems to work fine with some minimal tests, the midi messages often come from a separate thread so we may need to investigate how best to handle this with cinder/Signals. And what the worst case scenario would be for race conditions at this point..

Let me know what you think.