### PR TITLE
Better messaging in readme and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,9 @@ Cinder-MIDI2
 Alternative approach to interfacing RtMidi lib in Cinder
 Using
 ============
-Define preprocessor 
- __WINDOWS_MM__ on Windows
-__MACOSX_CORE__ on Mac OSX
- __LINUX_ALSA__ on Linux
  
 1. Create void function in your app, that will be reacting to incoming midi-messages:
+(This will be called on a background thread so be aware of race conditions with update() and draw())
 
  ```cpp
  

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Using
 ============
  
 1. Create void function in your app, that will be reacting to incoming midi-messages:
-(This will be called on a background thread so be aware of race conditions with update() and draw())
 
  ```cpp
  
@@ -32,7 +31,11 @@ Using
 
 2. connect signal from MidiInput instance to your function like so:
 
- ```mInput.midiSignal.connect(std::bind(&MidiTestApp::midiListener, this, std::placeholders::_1)); ```
+ ```mInput.midiSignal.connect( [this](midi::Message msg){ MidiTestApp::midiListener( msg ); }); ```
+
+ this will push the incoming midi messages safely over onto the main thread for consumption. You can however also get a signal directly from the midi thread if you need like so: 
+
+ ```mInput.midiThreadSignal.connect( [this](midi::Message msg){ MidiTestApp::midiListener( msg ); }); ```
 
  3. if you are using Windows, you need to add ```winmm.lib``` to your linker
 

--- a/include/MidiIn.h
+++ b/include/MidiIn.h
@@ -37,6 +37,7 @@ Midi parsing taken from openFrameworks addon ofxMidi by Theo Watson & Dan Wilcox
 
 #include "MidiHeaders.h"
 #include "cinder/Signals.h"
+#include "cinder/ConcurrentCircularBuffer.h"
 
 
 
@@ -53,6 +54,8 @@ public:
 	void listPorts();
 	void openPort(unsigned int port = 0);
 	void closePort();
+    
+    void setDispatchToMainThread(bool shouldDispatch) { mDispatchToMainThread = shouldDispatch; }
 	
 	unsigned int getNumPorts()const{ return mNumPorts; }
 	unsigned int getPort()const;
@@ -61,21 +64,19 @@ public:
 	std::vector<std::string> mPortNames;
 	std::string getName()	{ return mName; };
 	std::string getPortName(int number);
-    signals::Signal<void(Message)> midiSignal;
+    
+    signals::Signal<void(Message)>      midiThreadSignal;   // Will be called from the Midi thread
+    signals::Signal<void(Message)>      midiSignal;         // Will be called from the Main thread
 	
-	//typedef boost::signal<void (Message*)> signal_t;
-	// bool hasWaitingMessages();
-	//signal_t mSignal;
-	// bool getNextMessage(Message*);
 
 protected:
 	
-	RtMidiIn *mMidiIn;
-	unsigned int mNumPorts;
-	unsigned int mPort;
-	std::string mName;
-	//std::deque<Message*> mMessages;
-
+	RtMidiIn*       mMidiIn;
+	unsigned int    mNumPorts;
+	unsigned int    mPort;
+	std::string     mName;
+    
+    bool            mDispatchToMainThread { true };
 
 };
 

--- a/lib/RtMidi.h
+++ b/lib/RtMidi.h
@@ -568,7 +568,7 @@ inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, vo
 //
 // **************************************************************** //
 
-// Cinder Platform
+// Cinder Platform definitions
 #if defined( CINDER_LINUX )
 	#define __LINUX_ALSASEQ__
 #elif defined( CINDER_MSW )

--- a/sample/src/sampleApp.cpp
+++ b/sample/src/sampleApp.cpp
@@ -31,7 +31,9 @@ class MidiTestApp : public App {
 	
 };
 
-void MidiTestApp::midiListener(midi::Message msg){
+void MidiTestApp::midiListener(midi::Message msg)
+{
+    // This will be called from a background thread
 	switch (msg.status)
 	{
 	case MIDI_NOTE_ON:
@@ -55,17 +57,18 @@ void MidiTestApp::midiListener(midi::Message msg){
 
 void MidiTestApp::setup()
 {
-	
 	mInput.listPorts();
 	console() << "NUMBER OF PORTS: " << mInput.getNumPorts() << endl;
+    
 	if (mInput.getNumPorts() > 0) 
 	{
 		for (int i = 0; i < mInput.getNumPorts(); i++)
-		{
 			console() << mInput.getPortName(i) << endl;
-		}
+		
 		mInput.openPort(0);
-
+        
+        // Connect midi signal to our callback function
+        // (This will get called on a background thread so be aware of race conditions!)
 		mInput.midiSignal.connect(std::bind(&MidiTestApp::midiListener, this, std::placeholders::_1));
 	}
 
@@ -74,6 +77,7 @@ void MidiTestApp::setup()
 		notes.push_back(0);
 		cc.push_back(0);
 	}
+    
 	mFont = Font("Arial", 25);
 }
 

--- a/src/MidiIn.cpp
+++ b/src/MidiIn.cpp
@@ -113,7 +113,10 @@ namespace cinder { namespace midi {
 				break;
 			}
         
-            midiSignal.emit( msg );
+            midiThreadSignal.emit( msg );
+        
+            if (mDispatchToMainThread)
+                ci::app::App::get()->dispatchAsync( [this, msg](){ midiSignal.emit( msg ); });
 		}
 
 		// bool Input::hasWaitingMessages(){

--- a/src/MidiIn.cpp
+++ b/src/MidiIn.cpp
@@ -113,7 +113,6 @@ namespace cinder { namespace midi {
 				break;
 			}
         
-            // TODO: Ensure thread safety (or stick with boost)
             midiSignal.emit( msg );
 		}
 


### PR DESCRIPTION
Makes it clear to new users that midi messages arrive in your app on the midi thread.