### PR TITLE
Midi Thru

### DIFF
--- a/include/MidiIn.h
+++ b/include/MidiIn.h
@@ -67,7 +67,7 @@ public:
     
     signals::Signal<void(Message)>      midiThreadSignal;   // Will be called from the Midi thread
     signals::Signal<void(Message)>      midiSignal;         // Will be called from the Main thread
-	
+    signals::Signal<void( std::vector< unsigned char > )> midiRawSignal;
 
 protected:
 	

--- a/src/MidiIn.cpp
+++ b/src/MidiIn.cpp
@@ -117,6 +117,8 @@ namespace cinder { namespace midi {
         
             if (mDispatchToMainThread)
                 ci::app::App::get()->dispatchAsync( [this, msg](){ midiSignal.emit( msg ); });
+		std::vector<unsigned char> mess = *message;
+                ci::app::App::get()->dispatchAsync( [this, mess ](){ midiRawSignal.emit( mess ); });
 		}
 
 		// bool Input::hasWaitingMessages(){


### PR DESCRIPTION
I did this to forward the raw midi unsigned char to the midiOut low level sendMessage function.  It works, but I'm not sure how stable it is... Perhaps there is a better way?