### PR TITLE
cancel callback when closing port

### DIFF
--- a/src/MidiIn.cpp
+++ b/src/MidiIn.cpp
@@ -65,6 +65,7 @@ namespace cinder { namespace midi {
 
 	void Input::closePort(){
 		mMidiIn->closePort();
+		mMidiIn->cancelCallback();
 	}
 
 	void Input::processMessage(double deltatime, std::vector<unsigned char> *message){


### PR DESCRIPTION
When switching between MIDI ports, rtMidi was complaining about callbacks already being registered. This cancels any existing callbacks when a port is closed. 